### PR TITLE
correcting the norach line

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  python: noarch
+  noarch: python
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - wheel = wheel.tool:main


### PR DESCRIPTION
I had written python: noarch in the build section, but it should be noarch: python.
I had corrected that in terminal, and then re-rendered. But while commiting the changes I forgot to do a git add. Hence I commited the changes that was caused by re-rendering, and missed the changes in the meta.yaml.
Now, I just corrected the norach line and it should be fine.