### PR TITLE
fix: use native build system instead of compat script

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   host:
     - python >=3.7
-    - flit >=3.8
+    - flit-core >=3.8
   run:
     - python >=3.7
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,15 @@ source:
 build:
   noarch: python
   number: 1
-  script: {{ PYTHON }} -c "import flit_core.buildapi; flit_core.build_api.build_wheel('.')" && {{ PYTHON }} -m installer wheel-*.whl
+  script: {{ PYTHON }} -c "import flit_core.buildapi; flit_core.buildapi.build_wheel('.')" && {{ PYTHON }} -m installer wheel-*.whl
   entry_points:
     - wheel = wheel.cli:main
 
 requirements:
   host:
+    - flit-core
     - python >=3.7
     - python-installer
-    - flit-core
   run:
     - python >=3.7
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - python >=3.7
     - flit-core >=3.8
+    - pip
   run:
     - python >=3.7
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   noarch: python
   number: 1
-  script: {{ PYTHON }} -c "import flit_core.buildapi; flit_core.buildapi.build_wheel('.')" && {{ PYTHON }} -m installer wheel-*.whl
+  script: {{ PYTHON }} -c "import flit_core.buildapi; flit_core.buildapi.build_wheel('.')" && {{ PYTHON }} -m installer wheel-*.whl && ls -Rl $(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/wheel
   entry_points:
     - wheel = wheel.cli:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,14 @@ source:
 build:
   noarch: python
   number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m flit install --deps none
   entry_points:
     - wheel = wheel.cli:main
 
 requirements:
   host:
     - python >=3.7
-    - flit-core >=3.8
-    - pip
+    - flit
   run:
     - python >=3.7
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,15 +10,15 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - wheel = wheel.cli:main
 
 requirements:
   host:
     - python >=3.7
-    - setuptools >=45.2.0
+    - flit >=3.8
   run:
     - python >=3.7
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,14 +11,15 @@ source:
 build:
   noarch: python
   number: 1
-  script: {{ PYTHON }} -m flit install --deps none
+  script: {{ PYTHON }} -c "import flit_core.buildapi; flit_core.build_api.build_wheel('.')" && {{ PYTHON }} -m installer wheel-*.whl
   entry_points:
     - wheel = wheel.cli:main
 
 requirements:
   host:
     - python >=3.7
-    - flit
+    - python-installer
+    - flit-core
   run:
     - python >=3.7
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   noarch: python
   number: 1
-  script: {{ PYTHON }} -c "import flit_core.buildapi; flit_core.buildapi.build_wheel('.')" && {{ PYTHON }} -m installer --no-compile-bytecode wheel-*.whl && ls -Rl $(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/wheel
+  script: {{ PYTHON }} -c "import flit_core.buildapi; flit_core.buildapi.build_wheel('.')" && {{ PYTHON }} -m installer --no-compile-bytecode wheel-*.whl
   entry_points:
     - wheel = wheel.cli:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   noarch: python
   number: 1
-  script: {{ PYTHON }} -c "import flit_core.buildapi; flit_core.buildapi.build_wheel('.')" && {{ PYTHON }} -m installer wheel-*.whl && ls -Rl $(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/wheel
+  script: {{ PYTHON }} -c "import flit_core.buildapi; flit_core.buildapi.build_wheel('.')" && {{ PYTHON }} -m installer --no-compile-bytecode wheel-*.whl && ls -Rl $(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/wheel
   entry_points:
     - wheel = wheel.cli:main
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The setup.py in wheel is just a backward compat shim starting in 0.40.0. It now uses the flit-core build backend.
